### PR TITLE
[codex] Fix asset paths for GitHub Pages

### DIFF
--- a/app.js
+++ b/app.js
@@ -685,7 +685,7 @@ async function init(){
   // SW（オフライン化）
   if("serviceWorker" in navigator){
     try{
-      await navigator.serviceWorker.register("/service-worker.js", { scope: "/" });
+      await navigator.serviceWorker.register("./service-worker.js");
     }catch(e){
       console.warn("SW register failed", e);
     }

--- a/index.html
+++ b/index.html
@@ -6,9 +6,9 @@
   <meta name="theme-color" content="#0f766e" />
   <title>BodyLog（体組成ログ）</title>
 
-  <link rel="manifest" href="/manifest.webmanifest" />
-  <link rel="apple-touch-icon" href="/icons/icon-192.png" />
-  <link rel="stylesheet" href="/styles.css" />
+  <link rel="manifest" href="./manifest.webmanifest" />
+  <link rel="apple-touch-icon" href="./icons/icon-192.png" />
+  <link rel="stylesheet" href="./styles.css" />
 </head>
 <body>
   <header class="topbar">
@@ -218,7 +218,7 @@
   </main>
 
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
-  <script src="/app.js"></script>
+  <script src="./app.js"></script>
 </body>
 </html>
 

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -2,13 +2,13 @@
   "name": "BodyLog（体組成ログ）",
   "short_name": "BodyLog",
   "description": "体組成ログ（CSVインポート・日々入力・編集・グラフ）。端末内保存、オフライン対応。",
-  "start_url": "/",
-  "scope": "/",
+  "start_url": "./",
+  "scope": "./",
   "display": "standalone",
   "background_color": "#0b1220",
   "theme_color": "#0f766e",
   "icons": [
-    { "src": "/icons/icon-192.png", "sizes": "192x192", "type": "image/png" },
-    { "src": "/icons/icon-512.png", "sizes": "512x512", "type": "image/png" }
+    { "src": "./icons/icon-192.png", "sizes": "192x192", "type": "image/png" },
+    { "src": "./icons/icon-512.png", "sizes": "512x512", "type": "image/png" }
   ]
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,12 +1,12 @@
-const CACHE_NAME = "bodylog-shell-v3-20251229";
+const CACHE_NAME = "bodylog-shell-v3-20251229-pages-path";
 const APP_SHELL = [
-  "/",
-  "/index.html",
-  "/styles.css",
-  "/app.js",
-  "/manifest.webmanifest",
-  "/icons/icon-192.png",
-  "/icons/icon-512.png"
+  "./",
+  "./index.html",
+  "./styles.css",
+  "./app.js",
+  "./manifest.webmanifest",
+  "./icons/icon-192.png",
+  "./icons/icon-512.png"
 ];
 
 self.addEventListener("install", (event) => {


### PR DESCRIPTION
## Summary
- Change root-relative asset URLs to relative paths so the app works under the GitHub Pages project path.
- Update the web manifest and service worker cache entries to use the same relative path strategy.
- Bump the service worker cache name so old cached shell files are replaced.

## Validation
- node --check app.js
- node --check service-worker.js
- git diff --check