### PR TITLE
Fix Vite Pages deployment and Firebase config handling

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,58 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      VITE_FIREBASE_API_KEY: ${{ secrets.VITE_FIREBASE_API_KEY || vars.VITE_FIREBASE_API_KEY }}
+      VITE_FIREBASE_AUTH_DOMAIN: ${{ secrets.VITE_FIREBASE_AUTH_DOMAIN || vars.VITE_FIREBASE_AUTH_DOMAIN }}
+      VITE_FIREBASE_PROJECT_ID: ${{ secrets.VITE_FIREBASE_PROJECT_ID || vars.VITE_FIREBASE_PROJECT_ID }}
+      VITE_FIREBASE_STORAGE_BUCKET: ${{ secrets.VITE_FIREBASE_STORAGE_BUCKET || vars.VITE_FIREBASE_STORAGE_BUCKET }}
+      VITE_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.VITE_FIREBASE_MESSAGING_SENDER_ID || vars.VITE_FIREBASE_MESSAGING_SENDER_ID }}
+      VITE_FIREBASE_APP_ID: ${{ secrets.VITE_FIREBASE_APP_ID || vars.VITE_FIREBASE_APP_ID }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/index.html
+++ b/index.html
@@ -5,12 +5,11 @@
   <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover" />
   <meta name="theme-color" content="#0f766e" />
   <title>BodyLog</title>
-  <link rel="manifest" href="/body-composition-log/assets/manifest-DX6aLT_6.webmanifest" />
-  <link rel="apple-touch-icon" sizes="180x180" href="/body-composition-log/assets/icon-180-B561t4Rt.png" />
-  <script type="module" crossorigin src="/body-composition-log/assets/index-BUUdQCv-.js"></script>
-  <link rel="stylesheet" crossorigin href="/body-composition-log/assets/index-BA8Fp_aC.css">
+  <link rel="manifest" href="%BASE_URL%manifest.webmanifest" />
+  <link rel="apple-touch-icon" sizes="180x180" href="%BASE_URL%icons/icon-180.png" />
 </head>
 <body>
   <div id="root"></div>
+  <script type="module" src="/src/main.jsx"></script>
 </body>
 </html>

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -1,5 +1,4 @@
 import { initializeApp } from "firebase/app";
-
 import {
   getAuth,
   GoogleAuthProvider,
@@ -18,25 +17,40 @@ const firebaseConfig = {
   appId: import.meta.env.VITE_FIREBASE_APP_ID,
 };
 
-console.log(import.meta.env.VITE_FIREBASE_API_KEY);
+export const missingConfigKeys = Object.entries(firebaseConfig)
+  .filter(([, value]) => !value)
+  .map(([key]) => key);
 
-const app = initializeApp(firebaseConfig);
+export const isFirebaseConfigured = missingConfigKeys.length === 0;
 
-export const auth = getAuth(app);
-export const db = getFirestore(app);
+if (!isFirebaseConfigured) {
+  console.warn(`Firebase environment variables are missing: ${missingConfigKeys.join(", ")}`);
+}
+
+const app = isFirebaseConfigured ? initializeApp(firebaseConfig) : null;
+
+export const auth = app ? getAuth(app) : null;
+export const db = app ? getFirestore(app) : null;
 
 const provider = new GoogleAuthProvider();
+provider.setCustomParameters({
+  prompt: "select_account",
+});
 
 export const signInWithGoogle = async () => {
+  if (!auth) {
+    throw new Error("Firebase is not configured. Create a local .env file from .env.example.");
+  }
+
   return signInWithPopup(auth, provider);
 };
 
 export const logOut = async () => {
+  if (!auth) {
+    throw new Error("Firebase is not configured. Create a local .env file from .env.example.");
+  }
+
   return signOut(auth);
 };
-
-export const missingConfigKeys = [];
-
-export const isFirebaseConfigured = true;
 
 export default app;


### PR DESCRIPTION
## 概要
GitHub Pages のデプロイ構成を Vite 標準の build → dist 公開に修正します。

## 変更内容
- index.html を Vite の入力HTMLに戻す
- Firebase設定が未定義でも画面全体が落ちないように修正
- GitHub Actionsで npm run build → dist を Pages にデプロイする workflow を追加

## 確認
- npm.cmd run build 成功
- ローカルで /body-composition-log/ の表示確認済み
- GitHub Pages の subpath 用 asset path を確認済み
